### PR TITLE
Max consecutive ones iii

### DIFF
--- a/cmd/leetcode/main.go
+++ b/cmd/leetcode/main.go
@@ -1,10 +1,12 @@
 package main
 
-import maxsubarray1 "github.com/Andrew-Hinson/go-mastery/leetcode/maxSubArray-1"
+import (
+	"github.com/Andrew-Hinson/go-mastery/leetcode/maxConsecutiveOnesIII"
+)
 
 func main() {
-	nums := []int{1, 12, -5, -6, 50, 3}
-	k := 4
-	ans := maxsubarray1.FindMaxAverage(nums, k)
+	nums := []int{1, 1, 1, 0, 0, 0, 1, 1, 1, 1, 0}
+	k := 2
+	ans := maxConsecutiveOnesIII.FindMaxConsecutiveOnes(nums, k)
 	println(ans)
 }

--- a/cmd/leetcode/main.go
+++ b/cmd/leetcode/main.go
@@ -5,8 +5,8 @@ import (
 )
 
 func main() {
-	nums := []int{1, 1, 1, 0, 0, 0, 1, 1, 1, 1, 0}
-	k := 2
+	nums := []int{0, 0, 1, 1, 0, 0, 1, 1, 1, 0, 1, 1, 0, 0, 0, 1, 1, 1, 1}
+	k := 3
 	ans := maxConsecutiveOnesIII.FindMaxConsecutiveOnes(nums, k)
 	println(ans)
 }

--- a/leetcode/maxConsecutiveOnesIII/solution.go
+++ b/leetcode/maxConsecutiveOnesIII/solution.go
@@ -23,12 +23,12 @@ func FindMaxConsecutiveOnes(ones []int, k int) int {
 			if ones[left] == 0 {
 				curr -= 1
 			}
-			//this was a mistake. This increments the first value of the slice, not move the pointer
-			ones[left] += 1
-			println("curr value: ", curr)
+			//fixed mistake.
+			left += 1
 		}
 		if ans > right-left+1 {
-			ans = 0
+			//this was a gotcha, needs to be assigned to itself here - not 0 like I had before.
+			ans = ans
 		} else {
 			ans = right - left + 1
 		}

--- a/leetcode/maxConsecutiveOnesIII/solution.go
+++ b/leetcode/maxConsecutiveOnesIII/solution.go
@@ -7,3 +7,29 @@ package maxConsecutiveOnesIII
 //Output: 6
 //Explanation: [1,1,1,0,0,1,1,1,1,1,1]
 //Bolded numbers were flipped from 0 to 1. The longest subarray is underlined.
+
+// basically, what is the greatest number between right and left
+func findMaxConsecutiveOnes(ones []int, k int) int {
+	left := 0
+	ans := 0
+	//current is the number of 0s in the window
+	curr := 0
+	for right := range ones {
+		if ones[right] == 0 {
+			curr += 1
+		}
+		//while right has added more than 2 zeros to curr, bring left along with it till it gets to 0s and subtract from curr
+		for curr > 2 {
+			if ones[left] == 0 {
+				curr -= 1
+			}
+			ones[left] += 1
+		}
+		if ans > right-left+1 {
+			ans = 0
+		} else {
+			ans = right - left + 1
+		}
+	}
+	return ans
+}

--- a/leetcode/maxConsecutiveOnesIII/solution.go
+++ b/leetcode/maxConsecutiveOnesIII/solution.go
@@ -1,0 +1,9 @@
+package maxConsecutiveOnesIII
+
+//Given a binary array nums and an integer k,
+//return the maximum number of consecutive 1's in the array
+//if you can flip at most k 0's.
+//Input: nums = [1,1,1,0,0,0,1,1,1,1,0], k = 2
+//Output: 6
+//Explanation: [1,1,1,0,0,1,1,1,1,1,1]
+//Bolded numbers were flipped from 0 to 1. The longest subarray is underlined.

--- a/leetcode/maxConsecutiveOnesIII/solution.go
+++ b/leetcode/maxConsecutiveOnesIII/solution.go
@@ -26,10 +26,8 @@ func FindMaxConsecutiveOnes(ones []int, k int) int {
 			//fixed mistake.
 			left += 1
 		}
-		if ans > right-left+1 {
-			//this was a gotcha, needs to be assigned to itself here - not 0 like I had before.
-			ans = ans
-		} else {
+		//another gotcha, this is cleaner. and skips the self assignment issue.
+		if ans < right-left+1 {
 			ans = right - left + 1
 		}
 	}

--- a/leetcode/maxConsecutiveOnesIII/solution.go
+++ b/leetcode/maxConsecutiveOnesIII/solution.go
@@ -8,8 +8,8 @@ package maxConsecutiveOnesIII
 //Explanation: [1,1,1,0,0,1,1,1,1,1,1]
 //Bolded numbers were flipped from 0 to 1. The longest subarray is underlined.
 
-// basically, what is the greatest number between right and left
-func findMaxConsecutiveOnes(ones []int, k int) int {
+// FindMaxConsecutiveOnes = basically, what is the greatest number between right and left
+func FindMaxConsecutiveOnes(ones []int, k int) int {
 	left := 0
 	ans := 0
 	//current is the number of 0s in the window
@@ -19,11 +19,13 @@ func findMaxConsecutiveOnes(ones []int, k int) int {
 			curr += 1
 		}
 		//while right has added more than 2 zeros to curr, bring left along with it till it gets to 0s and subtract from curr
-		for curr > 2 {
+		for curr > k {
 			if ones[left] == 0 {
 				curr -= 1
 			}
+			//this was a mistake. This increments the first value of the slice, not move the pointer
 			ones[left] += 1
+			println("curr value: ", curr)
 		}
 		if ans > right-left+1 {
 			ans = 0

--- a/leetcode/maxConsecutiveOnesIII/solution_test.go
+++ b/leetcode/maxConsecutiveOnesIII/solution_test.go
@@ -19,6 +19,13 @@ func TestMaxConsecutiveOnes(t *testing.T) {
 				k:    3},
 			want: 10,
 		},
+		{
+			name: "second test",
+			args: args{
+				nums: []int{1, 1, 1, 0, 0, 0, 1, 1, 1, 1, 0},
+				k:    2},
+			want: 6,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/leetcode/maxConsecutiveOnesIII/solution_test.go
+++ b/leetcode/maxConsecutiveOnesIII/solution_test.go
@@ -1,1 +1,30 @@
 package maxConsecutiveOnesIII
+
+import "testing"
+
+func TestMaxConsecutiveOnes(t *testing.T) {
+	type args struct {
+		nums []int
+		k    int
+	}
+	tests := []struct {
+		name string
+		args args
+		want int
+	}{
+		{
+			name: "first test",
+			args: args{
+				nums: []int{0, 0, 1, 1, 0, 0, 1, 1, 1, 0, 1, 1, 0, 0, 0, 1, 1, 1, 1},
+				k:    3},
+			want: 10,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FindMaxConsecutiveOnes(tt.args.nums, tt.args.k); got != tt.want {
+				t.Errorf("FindConsecutiveOnes() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/leetcode/maxConsecutiveOnesIII/solution_test.go
+++ b/leetcode/maxConsecutiveOnesIII/solution_test.go
@@ -1,0 +1,1 @@
+package maxConsecutiveOnesIII


### PR DESCRIPTION
## This problem is solved with a sliding window. 
 
Instead of focusing on ones , I focused on 0s, since the k constraint was the limiting factor.
Add to curr the number of 0s encountered. Once curr is over the specified value, shift the left pointer and decrement the curr value.

Answer is derived from the right value minus the left value plus one for each iteration of the loop.

ans = right - left  + 1

then compare on each iteration if the previous answer is larger than this iteration. We are using ints not floats so no using math.Max() here.